### PR TITLE
MNISTデータを送信する際にラベルを選択しなくても送信できるようにした

### DIFF
--- a/components/PredictionCard.vue
+++ b/components/PredictionCard.vue
@@ -130,10 +130,10 @@ onBeforeUnmount(() => {
   <article class="rounded-xl border bg-white shadow-sm p-4">
     <header class="mb-3 flex items-center justify-between">
       <h2 class="text-sm font-semibold text-neutral-800">
-        Drawing #{{ props.drawingId }}
+        MNISTデータ #{{ props.drawingId }}
       </h2>
       <p v-if="predStatus" class="text-xs text-neutral-500">
-        status: <span class="tabular-nums">{{ predStatus }}</span>
+        ステータス: <span class="tabular-nums">{{ predStatus }}</span>
       </p>
     </header>
 
@@ -149,10 +149,10 @@ onBeforeUnmount(() => {
       <div class="flex-1 space-y-1">
         <div class="text-sm">
           ラベル:
-          <span class="font-mono text-base">{{ label }}</span>
+          <span class="font-mono text-base">{{ label ? label : "未定義" }}</span>
           <template v-if="predStatus === 'completed' && answer !== null">
             <span class="mx-2 text-neutral-400">/</span>
-            正解ラベル:
+            AI推測ラベル:
             <span class="font-mono text-base">{{ answer }}</span>
           </template>
         </div>
@@ -160,7 +160,7 @@ onBeforeUnmount(() => {
           Prediction #{{ props.predictionId }}
         </div>
         <div v-if="predStatus && predStatus !== 'completed' && predStatus !== 'failed'" class="text-xs text-neutral-500">
-          予測中…（3秒ごとに更新）
+          予測中…
         </div>
         <div v-if="predStatus === 'failed'" class="text-xs text-red-600">
           予測に失敗しました

--- a/composables/useMnistPredictions.ts
+++ b/composables/useMnistPredictions.ts
@@ -8,7 +8,7 @@ export function useMnistPredictions() {
   const config = useRuntimeConfig()
   const API = config.public.apiBase
 
-  const submit = async (label: number, file: File) => {
+  const submit = async (label: number | null, file: File) => {
     isSending.value = true
     try {
       const form = new FormData()

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -12,12 +12,7 @@
 
   const label = ref<number | null>(null)
 
-  async function submitDrawing() {
-    if (label.value == null) {
-      alert('正解ラベル（0~9）を選択してください')
-      return
-    }
-  
+  async function submitDrawing() {  
     try {
       const canvas = await to28x28Canvas()
       const blob = await toBlob(canvas, 'image/png')
@@ -72,7 +67,7 @@
           クリア
         </button>
 
-        <button type="button" @click="submitDrawing" :disabled="isSending || label === null"
+        <button type="button" @click="submitDrawing" :disabled="isSending"
           class="inline-flex items-center gap-2 rounded-md bg-black text-white px-3 py-2 text-sm disabled:opacity-50 hover:opacity-90 active:scale-[0.99] transition">
           {{ isSending ? '送信中...' : 'サンプル送信' }}
         </button>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -69,7 +69,7 @@
 
         <button type="button" @click="submitDrawing" :disabled="isSending"
           class="inline-flex items-center gap-2 rounded-md bg-black text-white px-3 py-2 text-sm disabled:opacity-50 hover:opacity-90 active:scale-[0.99] transition">
-          {{ isSending ? '送信中...' : 'サンプル送信' }}
+          {{ isSending ? '推論中...' : '推論開始' }}
         </button>
       </div>
     </div>


### PR DESCRIPTION
## 概要
MNISTデータを送信する際に、ラベルを選択しないと送信ボタンが押せないようにしていたが、推論をする際にはラベルを設定しなくても良いように修正した。