### PR TITLE
Clarify inference start button label

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -69,7 +69,7 @@
 
         <button type="button" @click="submitDrawing" :disabled="isSending"
           class="inline-flex items-center gap-2 rounded-md bg-black text-white px-3 py-2 text-sm disabled:opacity-50 hover:opacity-90 active:scale-[0.99] transition">
-          {{ isSending ? '送信中...' : 'サンプル送信' }}
+          {{ isSending ? '推論中...' : '推論開始' }}
         </button>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- make send button clearly indicate it starts inference

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c7a5c4ff808329aed101196cf7c320